### PR TITLE
New feature - user can create a template by assigning "Template" tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Install with [`ipm`](https://docs.inkdrop.app/manual/extend-inkdrop-with-plugins
 
 ### Create Templates
 
-You need to create note template in `_Templates` book of your inkdrop.
+You can create templates in two ways.
 
-:memo: Currently `_Templates` is hard code name, welcome to Pull Request!
+1. Create templates under `_Templates` notebook.
+2. Create templates by assigning `Template` tag to them.
 
-1. Create new `_Templates` notebook
-2. Add note as template  
+:memo: Currently `_Templates` and `Template` are hard-coded names, welcome to Pull Request!
 
 Note template should have content and metadata as [Yaml Front Matter](https://jekyllrb.com/docs/front-matter/).
 

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -94,6 +94,13 @@ module.exports = {
                 createdAt: +new Date(),
                 updatedAt: +new Date(),
             }
+            // remove Template tag from new note if any.
+            for (let tagIndex = note.tags.length - 1; tagIndex >= 0; tagIndex--) {
+                const tag = await db.tags.get(note.tags[tagIndex])
+                if (tag.name === "Template") {
+                    note.tags.splice(tagIndex, 1);
+                }
+            }
             console.log("new note", note);
             await db.notes.put(note)
             inkdrop.commands.dispatch(document.body, "core:open-note", {

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -4,16 +4,29 @@ const { Liquid } = require('liquidjs');
 const setupTemplates = async () => {
     const db = inkdrop.main.dataStore.getLocalDB()
     const TEMPLATE_NOTEBOOK_NAME = "_Templates";
+    const TEMPLATE_TAG_NAME = "Template";
+
+    let docs = Array();
+    // find notes in _Templates notebook.
     const templateBook = await db.books.findWithName(TEMPLATE_NOTEBOOK_NAME);
-    if (!templateBook) {
-        console.log(`Not found ${TEMPLATE_NOTEBOOK_NAME} notebook`)
-        return [];
+    if (templateBook) {
+        const notesInBook = await db.notes.findInBook(templateBook._id);
+        docs = docs.concat(notesInBook.docs);
     }
-    const { docs } = await db.notes.findInBook(templateBook._id);
+    // find notes with Template tag.
+    const templateTag = await db.tags.findWithName(TEMPLATE_TAG_NAME);
+    if (templateTag) {
+        const notesWithTag = await db.notes.findWithTag(templateTag._id);
+        docs = docs.concat(notesWithTag.docs);
+    }
+
     if (!docs) {
-        console.log(`Not found docs in ${TEMPLATE_NOTEBOOK_NAME}`);
+        console.log(`No note is found in ${TEMPLATE_NOTEBOOK_NAME} notebook or any note with ${TEMPLATE_TAG_NAME} tag.`);
         return [];
     }
+
+    console.log(docs);
+
     const promises = docs.map(async doc => {
         const { metadata, content } = metadataParser(doc.body);
         if (!metadata) {

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -6,28 +6,28 @@ const setupTemplates = async () => {
     const TEMPLATE_NOTEBOOK_NAME = "_Templates";
     const TEMPLATE_TAG_NAME = "Template";
 
-    let docs = Array();
+    let templateNotes = Array();
     // find notes in _Templates notebook.
     const templateBook = await db.books.findWithName(TEMPLATE_NOTEBOOK_NAME);
     if (templateBook) {
         const notesInBook = await db.notes.findInBook(templateBook._id);
-        docs = docs.concat(notesInBook.docs);
+        templateNotes = templateNotes.concat(notesInBook.docs);
     }
     // find notes with Template tag.
     const templateTag = await db.tags.findWithName(TEMPLATE_TAG_NAME);
     if (templateTag) {
         const notesWithTag = await db.notes.findWithTag(templateTag._id);
-        docs = docs.concat(notesWithTag.docs);
+        templateNotes = templateNotes.concat(notesWithTag.docs);
     }
 
-    if (!docs) {
+    if (!templateNotes) {
         console.log(`No note is found in ${TEMPLATE_NOTEBOOK_NAME} notebook or any note with ${TEMPLATE_TAG_NAME} tag.`);
         return [];
     }
 
-    console.log(docs);
+    console.log(templateNotes);
 
-    const promises = docs.map(async doc => {
+    const promises = templateNotes.map(async doc => {
         const { metadata, content } = metadataParser(doc.body);
         if (!metadata) {
             throw new Error("metadata should bw written as yaml front matter");

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -20,7 +20,7 @@ const setupTemplates = async () => {
         templateNotes = templateNotes.concat(notesWithTag.docs);
     }
 
-    if (!templateNotes) {
+    if (templateNotes.length === 0) {
         console.log(`No note is found in ${TEMPLATE_NOTEBOOK_NAME} notebook or any note with ${TEMPLATE_TAG_NAME} tag.`);
         return [];
     }

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -82,6 +82,8 @@ module.exports = {
             const currentBookId = queryContext.mode === "all"
                 ? state.config.core.defaultBook
                 : queryContext.bookId;
+            const templateTag = await db.tags.findWithName("Template");
+            const tagsWithoutTemplate = templateTag ? template.tags.filter(tag => tag !== templateTag._id) : template.tags;
             const note = {
                 ...template.doc,
                 _id: db.notes.createId(),
@@ -89,15 +91,9 @@ module.exports = {
                 _rev: undefined,
                 title: template.title,
                 body: template.body,
+                tags: tagsWithoutTemplate,
                 createdAt: +new Date(),
                 updatedAt: +new Date(),
-            }
-            // remove Template tag from new note if any.
-            for (let tagIndex = note.tags.length - 1; tagIndex >= 0; tagIndex--) {
-                const tag = await db.tags.get(note.tags[tagIndex])
-                if (tag.name === "Template") {
-                    note.tags.splice(tagIndex, 1);
-                }
             }
             console.log("new note", note);
             await db.notes.put(note)

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -83,7 +83,7 @@ module.exports = {
                 ? state.config.core.defaultBook
                 : queryContext.bookId;
             const templateTag = await db.tags.findWithName("Template");
-            const tagsWithoutTemplate = templateTag ? template.tags.filter(tag => tag !== templateTag._id) : template.tags;
+            const tagsWithoutTemplate = templateTag ? template.doc.tags.filter(tag => tag !== templateTag._id) : template.doc.tags;
             const note = {
                 ...template.doc,
                 _id: db.notes.createId(),

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -6,7 +6,7 @@ const setupTemplates = async () => {
     const TEMPLATE_NOTEBOOK_NAME = "_Templates";
     const TEMPLATE_TAG_NAME = "Template";
 
-    let templateNotes = Array();
+    let templateNotes = [];
     // find notes in _Templates notebook.
     const templateBook = await db.books.findWithName(TEMPLATE_NOTEBOOK_NAME);
     if (templateBook) {

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -4,12 +4,12 @@ const { Liquid } = require('liquidjs');
 const setupTemplates = async () => {
     const db = inkdrop.main.dataStore.getLocalDB()
     const TEMPLATE_NOTEBOOK_NAME = "_Templates";
-    const templateDocs = await db.books.findWithName(TEMPLATE_NOTEBOOK_NAME);
-    if (!templateDocs) {
+    const templateBook = await db.books.findWithName(TEMPLATE_NOTEBOOK_NAME);
+    if (!templateBook) {
         console.log(`Not found ${TEMPLATE_NOTEBOOK_NAME} notebook`)
         return [];
     }
-    const { docs } = await db.notes.findInBook(templateDocs._id);
+    const { docs } = await db.notes.findInBook(templateBook._id);
     if (!docs) {
         console.log(`Not found docs in ${TEMPLATE_NOTEBOOK_NAME}`);
         return [];

--- a/lib/inkdrop-note-templates.js
+++ b/lib/inkdrop-note-templates.js
@@ -25,8 +25,6 @@ const setupTemplates = async () => {
         return [];
     }
 
-    console.log(templateNotes);
-
     const promises = templateNotes.map(async doc => {
         const { metadata, content } = metadataParser(doc.body);
         if (!metadata) {


### PR DESCRIPTION
Hi @azu,

Thank you for developing such a good plugin. I am willing to contribute to it!

In previous design, the plugin searches templates under `_Templates` notebook. I enhanced the search so that notes with `Template` tag are considered templates and can be used to create new notes.

If user chooses to create a new note with tagged template, the plugin will remove `Template` tag from new created note because new created note is not a template.

Plugin loading flow chart:
![image](https://user-images.githubusercontent.com/38838945/110023223-e14dae00-7d67-11eb-9146-344ce50d1d22.png)
